### PR TITLE
feat(agents): implement EvidenceAgent — nomic-embed-text retrieval + …

### DIFF
--- a/agents/_llm.py
+++ b/agents/_llm.py
@@ -148,6 +148,15 @@ _MOCK_RESPONSES: dict[str, str] = {
             "reasoning_trace": "Mock toxicology reasoning — no real model was called.",
         }
     ),
+    # Claim evaluation response used by EvidenceAgent when calling meditron:70b.
+    # In practice MOCK_LLM short-circuits before claim eval is ever reached, but
+    # the entry is here so tests can patch call_chat and get a deterministic reply.
+    "evidence": json.dumps(
+        {
+            "verdict": "SUPPORTS",
+            "explanation": "Mock claim evaluation — no real model was called.",
+        }
+    ),
 }
 
 _MOCK_FALLBACK = json.dumps(

--- a/agents/evidence/__init__.py
+++ b/agents/evidence/__init__.py
@@ -1,0 +1,3 @@
+from agents.evidence.evidence_agent import EvidenceAgent
+
+__all__ = ["EvidenceAgent"]

--- a/agents/evidence/evidence_agent.py
+++ b/agents/evidence/evidence_agent.py
@@ -1,0 +1,283 @@
+"""Evidence grounding agent.
+
+Two-phase pipeline per ADR-002:
+
+1. **Retrieval** — embed each specialist diagnosis display string with
+   ``nomic-embed-text`` (Ollama ``/api/embeddings``), then run a pgvector
+   cosine-distance query against the ``evidence`` table.
+
+2. **Claim evaluation** — for every retrieved passage, ask ``meditron:70b``
+   (vLLM) whether the passage SUPPORTS, REFUTES, or is NEUTRAL toward the
+   candidate diagnosis. Only SUPPORTS passages become ``EvidenceCitation``
+   objects attached to ``DiagnosisCandidate.supporting_evidence``.
+
+Graceful degradation
+--------------------
+If the pgvector table is empty (or the similarity threshold returns no rows)
+the agent logs a warning and returns the diagnoses unchanged — no citations,
+no crash.
+
+Mock mode
+---------
+When ``settings.MOCK_LLM`` is ``True`` (the default for local development)
+the entire embedding + DB + claim-eval loop is skipped. The method returns an
+``EvidenceResult`` with the input diagnoses unmodified, identical to the
+empty-table degradation path.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from typing import TYPE_CHECKING, Any
+
+import httpx
+import structlog
+
+if TYPE_CHECKING:
+    import asyncpg as asyncpg_t
+
+from agents._llm import call_chat
+from agents.base import BaseAgent
+from agents.schemas import (
+    CaseObject,
+    DiagnosisCandidate,
+    EvidenceCitation,
+    EvidenceResult,
+    SpecialistResult,
+)
+from config import settings
+
+logger = structlog.get_logger()
+
+_CLAIM_EVAL_SYSTEM = """\
+You are a clinical evidence reviewer. Given a passage from a medical guideline
+or PubMed abstract and a proposed diagnosis, decide whether the passage
+supports or contradicts the diagnosis.
+
+Reply with ONLY valid JSON containing exactly two keys:
+  "verdict"     : one of "SUPPORTS", "REFUTES", or "NEUTRAL"
+  "explanation" : one sentence justifying your verdict
+"""
+
+_CLAIM_EVAL_USER = """\
+Passage:
+{excerpt}
+
+Source: {source}
+
+Proposed diagnosis: {diagnosis_display}
+
+Does this passage support the claim that "{diagnosis_display}" is the correct
+diagnosis for this patient? Answer SUPPORTS / REFUTES / NEUTRAL.
+"""
+
+# pgvector cosine-distance threshold: passages with distance ≥ this value are
+# considered too dissimilar to be useful evidence.
+_SIMILARITY_THRESHOLD = 0.4
+_MAX_PASSAGES = 5
+
+
+class EvidenceAgent(BaseAgent[EvidenceResult]):
+    """Evidence grounding using nomic-embed-text retrieval + meditron:70b claim eval."""
+
+    name = "evidence"
+    domain = "evidence"
+    model = "nomic-embed-text"  # primary: embedding via Ollama
+    inference_url = settings.OLLAMA_BASE_URL
+
+    # ---------------------------------------------------------------------------
+    # Public interface — overrides BaseAgent.run to accept specialist_results
+    # ---------------------------------------------------------------------------
+
+    async def run(  # type: ignore[override]
+        self,
+        case: CaseObject,
+        specialist_results: list[SpecialistResult],
+    ) -> EvidenceResult:
+        """Run evidence grounding and return an ``EvidenceResult``.
+
+        Overrides ``BaseAgent.run`` to accept the additional
+        ``specialist_results`` argument. Timing and structured logging mirror
+        the base implementation so observability is consistent across all agents.
+        """
+        start = time.monotonic()
+        log = logger.bind(agent=self.name, domain=self.domain, model=self.model)
+        log.info("agent.start", case_id=case.case_id)
+        try:
+            result = await self.reason(case, specialist_results)
+            elapsed_ms = (time.monotonic() - start) * 1000
+            log.info("agent.complete", case_id=case.case_id, elapsed_ms=round(elapsed_ms, 1))
+            return result
+        except Exception:
+            elapsed_ms = (time.monotonic() - start) * 1000
+            log.exception("agent.error", case_id=case.case_id, elapsed_ms=round(elapsed_ms, 1))
+            raise
+
+    async def reason(  # type: ignore[override]
+        self,
+        case: CaseObject,
+        specialist_results: list[SpecialistResult],
+    ) -> EvidenceResult:
+        """Ground each specialist diagnosis against the pgvector evidence corpus.
+
+        Parameters
+        ----------
+        case:
+            The patient case (used for ``case_id`` and logging context only at
+            this stage — the diagnoses themselves come from ``specialist_results``).
+        specialist_results:
+            Output from all specialist agents. Each ``SpecialistResult`` carries
+            a list of ``DiagnosisCandidate`` objects to be grounded.
+
+        Returns
+        -------
+        EvidenceResult
+            All diagnoses from every specialist result, with
+            ``supporting_evidence`` populated for candidates where at least one
+            SUPPORTS passage was found.
+        """
+        log = logger.bind(agent=self.name, case_id=case.case_id)
+
+        all_diagnoses: list[DiagnosisCandidate] = [
+            diagnosis
+            for sr in specialist_results
+            for diagnosis in sr.diagnoses
+        ]
+
+        if settings.MOCK_LLM:
+            return EvidenceResult(
+                agent_name=self.name,
+                case_id=case.case_id,
+                grounded_diagnoses=all_diagnoses,
+            )
+
+        import asyncpg  # lazy: not available in all dev environments
+
+        raw_dsn = settings.DATABASE_URL.replace("postgresql+asyncpg://", "postgresql://", 1)
+
+        conn: asyncpg_t.Connection = await asyncpg.connect(raw_dsn)
+        try:
+            for diagnosis in all_diagnoses:
+                await self._ground_diagnosis(diagnosis, conn, log)
+        finally:
+            await conn.close()
+
+        return EvidenceResult(
+            agent_name=self.name,
+            case_id=case.case_id,
+            grounded_diagnoses=all_diagnoses,
+        )
+
+    # ---------------------------------------------------------------------------
+    # Private helpers
+    # ---------------------------------------------------------------------------
+
+    async def _ground_diagnosis(
+        self,
+        diagnosis: DiagnosisCandidate,
+        conn: Any,
+        log: Any,
+    ) -> None:
+        """Embed one diagnosis, query pgvector, evaluate claims, attach citations."""
+        embedding = await self._embed(diagnosis.display)
+        passages = await self._query_pgvector(embedding, conn)
+
+        if not passages:
+            log.warning(
+                "evidence.no_passages",
+                diagnosis=diagnosis.display,
+                threshold=_SIMILARITY_THRESHOLD,
+            )
+            return
+
+        for passage in passages:
+            verdict = await self._evaluate_claim(
+                excerpt=passage["excerpt"],
+                source=passage["source"],
+                diagnosis_display=diagnosis.display,
+            )
+            if verdict == "SUPPORTS":
+                diagnosis.supporting_evidence.append(
+                    EvidenceCitation(
+                        source=passage["source"],
+                        excerpt=passage["excerpt"],
+                        relevance_score=float(passage.get("distance", 0.0)),
+                    )
+                )
+
+    async def _embed(self, text: str) -> list[float]:
+        """Return the nomic-embed-text embedding vector for *text*.
+
+        Calls the native Ollama ``/api/embeddings`` endpoint (not the OpenAI
+        ``/v1`` shim, which does not expose embedding generation for
+        nomic-embed-text).
+        """
+        ollama_root = settings.OLLAMA_BASE_URL.removesuffix("/v1")
+        async with httpx.AsyncClient(timeout=30.0) as client:
+            resp = await client.post(
+                f"{ollama_root}/api/embeddings",
+                json={"model": self.model, "prompt": text},
+            )
+            resp.raise_for_status()
+            return list(resp.json()["embedding"])
+
+    async def _query_pgvector(
+        self,
+        embedding: list[float],
+        conn: Any,
+    ) -> list[dict[str, Any]]:
+        """Query the pgvector ``evidence`` table for nearest-neighbour passages.
+
+        Returns up to ``_MAX_PASSAGES`` rows whose cosine distance to
+        *embedding* is below ``_SIMILARITY_THRESHOLD``.
+        """
+        rows = await conn.fetch(
+            """
+            SELECT excerpt, source, (embedding <-> $1::vector) AS distance
+            FROM evidence
+            WHERE embedding <-> $1::vector < $2
+            ORDER BY embedding <-> $1::vector
+            LIMIT $3
+            """,
+            json.dumps(embedding),
+            _SIMILARITY_THRESHOLD,
+            _MAX_PASSAGES,
+        )
+        return [dict(r) for r in rows]
+
+    async def _evaluate_claim(
+        self,
+        excerpt: str,
+        source: str,
+        diagnosis_display: str,
+    ) -> str:
+        """Ask meditron:70b whether *excerpt* supports *diagnosis_display*.
+
+        Returns one of ``"SUPPORTS"``, ``"REFUTES"``, or ``"NEUTRAL"``.
+        Defaults to ``"NEUTRAL"`` if the response cannot be parsed.
+        """
+        user_content = _CLAIM_EVAL_USER.format(
+            excerpt=excerpt,
+            source=source,
+            diagnosis_display=diagnosis_display,
+        )
+        messages = [
+            {"role": "system", "content": _CLAIM_EVAL_SYSTEM},
+            {"role": "user", "content": user_content},
+        ]
+        raw = await call_chat(
+            settings.VLLM_BASE_URL,
+            "meditron:70b",
+            messages,
+            response_format={"type": "json_object"},
+            mock_domain=self.domain,
+        )
+        try:
+            payload: dict[str, Any] = json.loads(raw)
+            verdict = str(payload.get("verdict", "NEUTRAL")).upper()
+            if verdict not in {"SUPPORTS", "REFUTES", "NEUTRAL"}:
+                return "NEUTRAL"
+            return verdict
+        except (json.JSONDecodeError, KeyError):
+            return "NEUTRAL"

--- a/agents/schemas.py
+++ b/agents/schemas.py
@@ -113,6 +113,12 @@ class SafetyResult(AgentResult):
     decisions: list[VetoDecision] = Field(default_factory=list)
 
 
+class EvidenceResult(AgentResult):
+    """Result produced by the evidence grounding agent."""
+
+    grounded_diagnoses: list[DiagnosisCandidate] = Field(default_factory=list)
+
+
 class DifferentialReport(BaseModel):
     """Final synthesized output written as a FHIR DiagnosticReport."""
 

--- a/config.py
+++ b/config.py
@@ -23,6 +23,12 @@ class Settings(BaseSettings):
     OLLAMA_BASE_URL: str = "http://localhost:11434/v1"
     VLLM_BASE_URL: str = "http://localhost:8080/v1"
 
+    # ── Database ───────────────────────────────────────────────────────────
+    # SQLAlchemy-style DSN (used by SQLAlchemy ORM and the API layer).
+    # EvidenceAgent strips the "+asyncpg" dialect prefix when opening a raw
+    # asyncpg connection for the pgvector similarity query.
+    DATABASE_URL: str = "postgresql+asyncpg://shadi:shadi@localhost:5432/shadi"
+
     # ── Local-dev mock flag ────────────────────────────────────────────────
     # Default True so the agents run without downloaded models.
     # Set MOCK_LLM=false in .env (or the environment) on the DGX.

--- a/tests/unit/test_agents.py
+++ b/tests/unit/test_agents.py
@@ -14,18 +14,24 @@ Coverage:
   - DiagnosisCandidate confidence values sum ≤ 1.0 for every specialist
   - Custom mock: overriding call_chat to test specific payloads
   - Custom mock: handling of partial/missing JSON keys
+  - EvidenceAgent mock-mode short-circuit (no DB, no crash)
+  - EvidenceAgent attaches EvidenceCitation when claim eval returns SUPPORTS
+  - EvidenceAgent skips citation when claim eval returns REFUTES
+  - EvidenceAgent graceful degradation when pgvector returns no rows
+  - EvidenceAgent inference_url routes to Ollama
 """
 
 from __future__ import annotations
 
 import json
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 from uuid import uuid4
 
 import pytest
 
+from agents.evidence.evidence_agent import EvidenceAgent
 from agents.intake.intake_agent import IntakeAgent
-from agents.schemas import CaseObject, SpecialistResult
+from agents.schemas import CaseObject, DiagnosisCandidate, EvidenceResult, SpecialistResult
 from agents.specialists.cardiology_agent import CardiologyAgent
 from agents.specialists.image_agent import ImageAnalysisAgent
 from agents.specialists.neurology_agent import NeurologyAgent
@@ -293,3 +299,198 @@ async def test_result_case_id_matches_input():
         assert result.case_id == case.case_id, (
             f"{AgentClass.__name__} returned wrong case_id"
         )
+
+
+# ── EvidenceAgent ─────────────────────────────────────────────────────────────
+
+def fresh_specialist_result() -> SpecialistResult:
+    """Return a deep-copied cardiology SpecialistResult for evidence tests.
+
+    Must be called fresh per test so mutations to DiagnosisCandidate.supporting_evidence
+    in one test do not bleed into the next.
+    """
+    return SpecialistResult(
+        agent_name="cardiology",
+        case_id=MOCK_CASE.case_id,
+        domain="cardiology",
+        diagnoses=[
+            DiagnosisCandidate(
+                rank=1,
+                display="Acute myocardial infarction",
+                confidence=0.75,
+                snomed_code="57054005",
+            )
+        ],
+        reasoning_trace="Test trace.",
+    )
+
+
+# Module-level alias for tests that don't mutate the diagnoses list.
+_EVIDENCE_SPECIALIST_RESULT = fresh_specialist_result()
+
+
+def test_evidence_agent_describe():
+    d = EvidenceAgent().describe()
+    assert d["name"] == "evidence"
+    assert d["domain"] == "evidence"
+    assert d["model"] == "nomic-embed-text"
+
+
+def test_evidence_agent_uses_ollama():
+    assert EvidenceAgent.inference_url == settings.OLLAMA_BASE_URL
+
+
+async def test_evidence_agent_mock_mode_no_crash():
+    """MOCK_LLM=True (default): run completes without touching DB or Ollama."""
+    case = fresh_case()
+    result = await EvidenceAgent().run(case, [_EVIDENCE_SPECIALIST_RESULT])
+    assert isinstance(result, EvidenceResult)
+    assert result.agent_name == "evidence"
+    assert result.case_id == case.case_id
+
+
+async def test_evidence_agent_mock_mode_returns_diagnoses_unchanged():
+    """In mock mode, grounded_diagnoses contains the input candidates unmodified."""
+    case = fresh_case()
+    result = await EvidenceAgent().run(case, [_EVIDENCE_SPECIALIST_RESULT])
+    assert len(result.grounded_diagnoses) == 1
+    assert result.grounded_diagnoses[0].display == "Acute myocardial infarction"
+    assert result.grounded_diagnoses[0].supporting_evidence == []
+
+
+async def test_evidence_agent_mock_mode_skips_embed():
+    """Confirm the Ollama /api/embeddings endpoint is never called in mock mode."""
+    case = fresh_case()
+    with patch("agents.evidence.evidence_agent.httpx.AsyncClient") as mock_client:
+        await EvidenceAgent().run(case, [_EVIDENCE_SPECIALIST_RESULT])
+        mock_client.assert_not_called()
+
+
+def _make_real_mode_patches(mock_conn: MagicMock, mock_http_resp_embedding: list[float]):
+    """Return context-manager patches shared by real-mode evidence tests.
+
+    asyncpg is imported lazily inside EvidenceAgent.reason, so we patch it via
+    the ``sys.modules`` shim rather than a module-level attribute.
+    """
+    import sys
+    import types
+
+    asyncpg_stub = types.ModuleType("asyncpg")
+    asyncpg_stub.connect = AsyncMock(return_value=mock_conn)  # type: ignore[attr-defined]
+    sys.modules.setdefault("asyncpg", asyncpg_stub)
+    # Override connect regardless of whether asyncpg was already in sys.modules.
+    sys.modules["asyncpg"].connect = AsyncMock(return_value=mock_conn)  # type: ignore[attr-defined]
+
+    mock_resp = MagicMock()
+    mock_resp.json.return_value = {"embedding": mock_http_resp_embedding}
+    mock_resp.raise_for_status = MagicMock()
+    mock_http = MagicMock()
+    mock_http.__aenter__ = AsyncMock(
+        return_value=MagicMock(post=AsyncMock(return_value=mock_resp))
+    )
+    mock_http.__aexit__ = AsyncMock(return_value=False)
+
+    return mock_http
+
+
+async def test_evidence_agent_empty_pgvector_no_crash():
+    """Real-mode: empty pgvector table → no citations, no exception."""
+    case = fresh_case()
+
+    mock_conn = MagicMock()
+    mock_conn.fetch = AsyncMock(return_value=[])
+    mock_conn.close = AsyncMock()
+    mock_http = _make_real_mode_patches(mock_conn, [0.1] * 768)
+
+    with (
+        patch("agents.evidence.evidence_agent.settings") as mock_settings,
+        patch("agents.evidence.evidence_agent.httpx.AsyncClient", return_value=mock_http),
+    ):
+        mock_settings.MOCK_LLM = False
+        mock_settings.OLLAMA_BASE_URL = settings.OLLAMA_BASE_URL
+        mock_settings.VLLM_BASE_URL = settings.VLLM_BASE_URL
+        mock_settings.DATABASE_URL = "postgresql+asyncpg://shadi:shadi@localhost:5432/shadi"
+
+        result = await EvidenceAgent().run(case, [_EVIDENCE_SPECIALIST_RESULT])
+
+    assert isinstance(result, EvidenceResult)
+    assert result.grounded_diagnoses[0].supporting_evidence == []
+
+
+async def test_evidence_agent_supports_attaches_citation():
+    """Real-mode: SUPPORTS verdict → EvidenceCitation is appended."""
+    case = fresh_case()
+
+    mock_row = {"excerpt": "AMI is the leading cause...", "source": "PubMed:12345678", "distance": 0.25}
+    mock_conn = MagicMock()
+    mock_conn.fetch = AsyncMock(return_value=[mock_row])
+    mock_conn.close = AsyncMock()
+    mock_http = _make_real_mode_patches(mock_conn, [0.1] * 768)
+
+    supports_payload = json.dumps({"verdict": "SUPPORTS", "explanation": "Directly relevant."})
+
+    with (
+        patch("agents.evidence.evidence_agent.settings") as mock_settings,
+        patch("agents.evidence.evidence_agent.httpx.AsyncClient", return_value=mock_http),
+        patch("agents.evidence.evidence_agent.call_chat", AsyncMock(return_value=supports_payload)),
+    ):
+        mock_settings.MOCK_LLM = False
+        mock_settings.OLLAMA_BASE_URL = settings.OLLAMA_BASE_URL
+        mock_settings.VLLM_BASE_URL = settings.VLLM_BASE_URL
+        mock_settings.DATABASE_URL = "postgresql+asyncpg://shadi:shadi@localhost:5432/shadi"
+
+        result = await EvidenceAgent().run(case, [fresh_specialist_result()])
+
+    citations = result.grounded_diagnoses[0].supporting_evidence
+    assert len(citations) == 1
+    assert citations[0].source == "PubMed:12345678"
+    assert citations[0].excerpt == "AMI is the leading cause..."
+
+
+async def test_evidence_agent_refutes_no_citation():
+    """Real-mode: REFUTES verdict → no EvidenceCitation is attached."""
+    case = fresh_case()
+
+    mock_row = {"excerpt": "Unrelated passage.", "source": "PubMed:99999999", "distance": 0.38}
+    mock_conn = MagicMock()
+    mock_conn.fetch = AsyncMock(return_value=[mock_row])
+    mock_conn.close = AsyncMock()
+    mock_http = _make_real_mode_patches(mock_conn, [0.1] * 768)
+
+    refutes_payload = json.dumps({"verdict": "REFUTES", "explanation": "Contradicts AMI."})
+
+    with (
+        patch("agents.evidence.evidence_agent.settings") as mock_settings,
+        patch("agents.evidence.evidence_agent.httpx.AsyncClient", return_value=mock_http),
+        patch("agents.evidence.evidence_agent.call_chat", AsyncMock(return_value=refutes_payload)),
+    ):
+        mock_settings.MOCK_LLM = False
+        mock_settings.OLLAMA_BASE_URL = settings.OLLAMA_BASE_URL
+        mock_settings.VLLM_BASE_URL = settings.VLLM_BASE_URL
+        mock_settings.DATABASE_URL = "postgresql+asyncpg://shadi:shadi@localhost:5432/shadi"
+
+        result = await EvidenceAgent().run(case, [fresh_specialist_result()])
+
+    assert result.grounded_diagnoses[0].supporting_evidence == []
+
+
+async def test_evidence_agent_result_case_id_matches_input():
+    case = fresh_case()
+    result = await EvidenceAgent().run(case, [_EVIDENCE_SPECIALIST_RESULT])
+    assert result.case_id == case.case_id
+
+
+async def test_evidence_agent_multiple_specialist_results():
+    """All diagnoses from multiple specialist results are collected."""
+    case = fresh_case()
+    neuro_result = SpecialistResult(
+        agent_name="neurology",
+        case_id=case.case_id,
+        domain="neurology",
+        diagnoses=[
+            DiagnosisCandidate(rank=1, display="Cerebrovascular accident", confidence=0.55)
+        ],
+        reasoning_trace="",
+    )
+    result = await EvidenceAgent().run(case, [_EVIDENCE_SPECIALIST_RESULT, neuro_result])
+    assert len(result.grounded_diagnoses) == 2


### PR DESCRIPTION
…meditron:70b claim eval

Closes #37.

- Add EvidenceResult(AgentResult) to agents/schemas.py
- Add DATABASE_URL to config.py Settings (raw asyncpg DSN derived at runtime)
- Add "evidence" mock domain to agents/_llm.py for claim-eval test fixtures
- Implement EvidenceAgent in agents/evidence/evidence_agent.py:
  - Embeds each DiagnosisCandidate display string via POST /api/embeddings (Ollama)
  - Queries pgvector evidence table (cosine distance < 0.4, limit 5)
  - Evaluates each retrieved passage with meditron:70b via vLLM (SUPPORTS/REFUTES/NEUTRAL)
  - Attaches EvidenceCitation objects only for SUPPORTS verdicts
  - Graceful degradation: empty pgvector table → log warning, return diagnoses unchanged
  - MOCK_LLM=True short-circuits before any DB or embedding calls
  - asyncpg imported lazily to support dev environments without a wheel
- Export EvidenceAgent from agents/evidence/__init__.py
- Add 10 unit tests covering mock-mode, empty table, SUPPORTS, REFUTES, multi-specialist

Made-with: Cursor