### PR TITLE
feat(fhir): issue #29 — DELETE Subscription on stop, tolerate 404

### DIFF
--- a/shadi_fhir/mcp_server.py
+++ b/shadi_fhir/mcp_server.py
@@ -1,7 +1,4 @@
-"""FHIR R4 MCP server — OAuth, Subscription, and notifications (issues #26–#27).
-
-Subscription DELETE on shutdown is issue #29.
-"""
+"""FHIR R4 MCP server — OAuth (#26), Subscription + notify (#27), clean shutdown (#29)."""
 
 from __future__ import annotations
 
@@ -145,7 +142,27 @@ class FHIRMCPServer:
         logger.info("fhir.mcp_server.started", base_url=self._base_url)
 
     async def stop(self) -> None:
-        """Close arq pool and HTTP client (issue #29 adds Subscription DELETE)."""
+        """DELETE Subscription (best-effort), close arq pool and HTTP client."""
+        if self._subscription_id and self._http is not None:
+            try:
+                token = await self._get_token()
+                r = await self._http.delete(
+                    f"/Subscription/{self._subscription_id}",
+                    headers=self._fhir_headers(token),
+                )
+                if r.status_code == 404:
+                    logger.info(
+                        "fhir.subscription.already_deleted",
+                        subscription_id=self._subscription_id,
+                    )
+                elif not r.is_success:
+                    logger.warning(
+                        "fhir.subscription.delete_status",
+                        status_code=r.status_code,
+                        subscription_id=self._subscription_id,
+                    )
+            except Exception as exc:
+                logger.warning("fhir.subscription.delete_exception", error=str(exc))
         self._subscription_id = None
         if self._arq is not None:
             try:

--- a/tests/unit/test_fhir_mcp_server.py
+++ b/tests/unit/test_fhir_mcp_server.py
@@ -96,9 +96,13 @@ async def test_start_registers_subscription() -> None:
             )
         raise AssertionError(f"unexpected POST {u!r}")
 
+    async def delete_side_effect(url: str, **kwargs: object) -> httpx.Response:
+        assert "sub-99" in str(url)
+        return _http_response(204, method="DELETE", url=str(url))
+
     mock_http = AsyncMock()
     mock_http.post = AsyncMock(side_effect=post_side_effect)
-    mock_http.delete = AsyncMock()
+    mock_http.delete = AsyncMock(side_effect=delete_side_effect)
     mock_http.aclose = AsyncMock()
 
     mock_arq = AsyncMock()
@@ -114,7 +118,32 @@ async def test_start_registers_subscription() -> None:
 
     assert server._subscription_id == "sub-99"
     await server.stop()
+    mock_http.delete.assert_awaited()
     mock_arq.close.assert_awaited()
+    mock_http.aclose.assert_awaited()
+
+
+@pytest.mark.asyncio
+async def test_stop_swallows_404_on_delete() -> None:
+    server = _make_server()
+    server._subscription_id = "gone"
+    server._access_token = "t"
+    server._token_deadline_monotonic = 1e12
+
+    mock_http = AsyncMock()
+    mock_http.delete = AsyncMock(
+        return_value=_http_response(
+            404,
+            method="DELETE",
+            url="https://fhir.example.org/R4/Subscription/gone",
+        )
+    )
+    mock_http.aclose = AsyncMock()
+    server._http = mock_http
+    server._arq = None
+
+    await server.stop()
+    mock_http.delete.assert_awaited()
     mock_http.aclose.assert_awaited()
 
 


### PR DESCRIPTION
### Scope — GitHub issue [#29](https://github.com/noahvar15/shadi/issues/29)

- On MCP **shutdown**, **DELETE** the active FHIR Subscription on the server.
- Treat **HTTP 404** as success when the subscription no longer exists, so teardown does not fail.

### Merge order

This PR targets **`feat/fhir-27`**. Complete [PR #55](https://github.com/noahvar15/shadi/pull/55) and [PR #56](https://github.com/noahvar15/shadi/pull/56) (or rebase this branch onto `main` once those commits are there) before merging.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced the shutdown process to properly remove subscriptions from the FHIR server when available.
  * Server now gracefully handles subscription deletion failures and already-deleted subscriptions without interrupting shutdown.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
