### PR TITLE
chore(integration): verify API #31–#34 stack; lazy arq worker settings

### DIFF
--- a/scripts/verify_api_tracks_integration.sh
+++ b/scripts/verify_api_tracks_integration.sh
@@ -14,6 +14,10 @@ refs=(
   origin/issue/34-arq-worker-and-tests
 )
 for ref in "${refs[@]}"; do
+  if ! git rev-parse --verify -q "$ref" >/dev/null; then
+    echo "FAIL: ref $ref does not exist after fetch (remote branch deleted or typo)." >&2
+    exit 1
+  fi
   if git merge-base --is-ancestor "$ref" HEAD; then
     echo "OK: $ref is an ancestor of HEAD"
   else

--- a/tasks/worker.py
+++ b/tasks/worker.py
@@ -11,6 +11,24 @@ from api.db import close_pool, init_pool
 from tasks.pipeline import run_diagnostic_pipeline
 
 
+def _arq_worker_kwargs_filtered() -> dict[str, Any]:
+    """Kwargs arq's ``Worker`` accepts, built lazily (``get_settings()`` not at import)."""
+    from inspect import signature
+
+    from arq.worker import Worker
+
+    s = get_settings()
+    snap = {
+        "functions": [run_diagnostic_pipeline],
+        "redis_settings": RedisSettings.from_dsn(s.redis_url),
+        "queue_name": s.intake_queue,
+        "on_startup": startup,
+        "on_shutdown": shutdown,
+    }
+    worker_args = set(signature(Worker).parameters.keys())
+    return {k: v for k, v in snap.items() if k in worker_args}
+
+
 async def startup(ctx: dict[str, Any]) -> None:
     """Open the asyncpg pool and store it on the arq job context."""
     settings = get_settings()
@@ -23,37 +41,61 @@ async def shutdown(ctx: dict[str, Any]) -> None:
 
 
 class _ArqWorkerSettings(dict):
-    """Lazy arq kwargs (dict form) so importing this module does not call ``get_settings()``."""
+    """Dict-shaped arq settings: reads delegate to a lazy snapshot (no import-time env).
+
+    Subclasses ``dict`` so ``isinstance(..., dict)`` and arq's ``get_kwargs`` path work.
+    All read operations go through the same filtered mapping so ``dict(WorkerSettings)``,
+    iteration, ``keys()``, and ``bool()`` stay consistent (not an empty backing dict).
+    """
 
     __slots__ = ()
 
-    def _snapshot(self) -> dict[str, Any]:
-        s = get_settings()
-        return {
-            "functions": [run_diagnostic_pipeline],
-            "redis_settings": RedisSettings.from_dsn(s.redis_url),
-            "queue_name": s.intake_queue,
-            "on_startup": startup,
-            "on_shutdown": shutdown,
-        }
+    def _mapping(self) -> dict[str, Any]:
+        return _arq_worker_kwargs_filtered()
+
+    def __getitem__(self, key: str) -> Any:  # type: ignore[override]
+        return self._mapping()[key]
+
+    def __iter__(self):  # type: ignore[override]
+        return iter(self._mapping())
+
+    def __len__(self) -> int:  # type: ignore[override]
+        return len(self._mapping())
+
+    def __bool__(self) -> bool:
+        return bool(self._mapping())
+
+    def __contains__(self, key: object) -> bool:  # type: ignore[override]
+        return key in self._mapping()
+
+    def get(self, key: str, default: Any = None) -> Any:  # type: ignore[override]
+        return self._mapping().get(key, default)
+
+    def keys(self):  # type: ignore[override]
+        return self._mapping().keys()
+
+    def values(self):  # type: ignore[override]
+        return self._mapping().values()
 
     def items(self):  # type: ignore[override]
-        from inspect import signature
+        return self._mapping().items()
 
-        from arq.worker import Worker
-
-        snap = self._snapshot()
-        worker_args = set(signature(Worker).parameters.keys())
-        return [(k, v) for k, v in snap.items() if k in worker_args]
+    def copy(self) -> dict[str, Any]:  # type: ignore[override]
+        return self._mapping().copy()
 
     def __getattr__(self, name: str) -> Any:
         if name.startswith("_"):
             raise AttributeError(name)
-        snap = self._snapshot()
-        try:
-            return snap[name]
-        except KeyError as e:
-            raise AttributeError(name) from e
+        m = self._mapping()
+        if name in m:
+            return m[name]
+        raise AttributeError(name)
+
+    def __setitem__(self, key: Any, value: Any) -> None:  # type: ignore[override]
+        raise TypeError("WorkerSettings mapping is read-only")
+
+    def __delitem__(self, key: Any) -> None:  # type: ignore[override]
+        raise TypeError("WorkerSettings mapping is read-only")
 
 
 WorkerSettings: _ArqWorkerSettings = _ArqWorkerSettings()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,7 +12,11 @@ from starlette.testclient import TestClient
 
 
 def pytest_configure(config: pytest.Config) -> None:
-    """Defaults for CI / bare shells so ``get_settings()`` succeeds when tests run without ``.env``."""
+    """Defaults for CI / bare shells so ``get_settings()`` succeeds when tests run without ``.env``.
+
+    Uses ``setdefault`` only: a real ``.env`` or exported vars still win. Tests that hit the DB
+    must mock ``init_pool`` / use ``TestClient`` patches like ``patched_api_app``.
+    """
     os.environ.setdefault(
         "DATABASE_URL",
         "postgresql+asyncpg://pytest:pytest@127.0.0.1:5432/pytest",

--- a/tests/unit/test_api_issue_34.py
+++ b/tests/unit/test_api_issue_34.py
@@ -18,6 +18,18 @@ def test_worker_settings_exposes_pipeline_and_hooks() -> None:
     assert WorkerSettings.redis_settings is not None
 
 
+def test_worker_settings_dict_protocol_matches_lazy_snapshot() -> None:
+    """Regression: dict views must not be empty (arq / dict() / iteration)."""
+    from arq.worker import get_kwargs
+
+    m = dict(WorkerSettings)
+    assert bool(WorkerSettings)
+    assert len(WorkerSettings) == len(m)
+    assert set(m.keys()) == set(WorkerSettings.keys())
+    assert get_kwargs(WorkerSettings) == m
+    assert run_diagnostic_pipeline in m["functions"]
+
+
 @pytest.mark.asyncio
 async def test_worker_startup_stores_pool(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("DATABASE_URL", "postgresql+asyncpg://u:p@127.0.0.1:9/nope")


### PR DESCRIPTION
## Summary

`main` already contains the stacked API work from issues **#31–#34** (merged via PRs through [#61](https://github.com/noahvar15/shadi/pull/61)). This PR adds a repeatable check that those branches are still ancestors of the current line of history and that the full suite passes. It also fixes import-time `get_settings()` in the arq worker module and missing env defaults in bare test runs.

## Changes

- **`tasks/worker.py`** — Do not call `get_settings()` at import. `WorkerSettings` is a lazy dict-shaped object compatible with arq’s `get_kwargs()` (via `items()`), with attribute access preserved for `tests/unit/test_api_issue_34.py`.
- **`tests/conftest.py`** — In `pytest_configure`, `setdefault` `DATABASE_URL` and `API_SECRET_KEY` for CI / shells without `.env` (without overriding existing env).
- **`scripts/verify_api_tracks_integration.sh`** — `git fetch` origin, verify `origin/issue/31-api-lifespan-settings`, `origin/issue/32-post-cases-intake`, `origin/issue/33-reports-pipeline-stub`, and `origin/issue/34-arq-worker-and-tests` are ancestors of `HEAD`, then run `pytest tests/`.

## How to verify

```bash
./scripts/verify_api_tracks_integration.sh

.venv/bin/python -m pytest tests/ -q


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a verification script to check API branch integration and run tests.

* **Refactor**
  * Worker configuration now resolves settings lazily at runtime for more reliable startup behavior.

* **Tests**
  * Test environment auto-populates default config variables.
  * Added a unit test to validate the worker settings expose a dict-like snapshot consistent with runtime view.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->