### PR TITLE
fix: correct medgemma Ollama registry tag to alibayram/medgemma:27b

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -32,7 +32,7 @@ VLLM_BASE_URL=http://localhost:8080/v1
 
 # ─── Ollama / All Other Agents ────────────────────────────────────────────────
 # Serves all non-specialist models. Pull models on first boot with:
-#   docker exec shadi-ollama-1 ollama pull medgemma:27b
+#   docker exec shadi-ollama-1 ollama pull alibayram/medgemma:27b
 #   docker exec shadi-ollama-1 ollama pull qwen2.5:7b
 #   docker exec shadi-ollama-1 ollama pull nomic-embed-text
 #   docker exec shadi-ollama-1 ollama pull phi4:14b
@@ -41,7 +41,7 @@ OLLAMA_BASE_URL=http://localhost:11434/v1
 
 # ─── Model Assignments (see ADR-002) ──────────────────────────────────────────
 # Image analysis agent (multimodal — radiographs, ECGs, CT scouts)
-IMAGE_MODEL=medgemma:27b
+IMAGE_MODEL=alibayram/medgemma:27b
 
 # Intake agent (SNOMED/LOINC/RxNorm extraction from triage notes)
 INTAKE_MODEL=qwen2.5:7b

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Two inference servers run side-by-side. vLLM handles the specialists (LoRA hot-s
 
 | Agent | Model | Server | Approx VRAM |
 |---|---|---|---|
-| Image analysis | `medgemma:27b` | Ollama | ~16 GB |
+| Image analysis | `alibayram/medgemma:27b` | Ollama | ~17 GB |
 | Intake | `qwen2.5:7b` | Ollama | ~4.5 GB |
 | Specialists ×4 (base) | `meditron:70b` FP4 | vLLM | ~38 GB |
 | Specialist LoRA adapters ×4 | cardiology / neurology / pulmonology / toxicology | vLLM | ~8 GB |
@@ -126,7 +126,7 @@ docker compose up
 On first boot, pull the Ollama models (vLLM loads Meditron from the path in `.env`):
 
 ```bash
-docker exec shadi-ollama-1 ollama pull medgemma:27b
+docker exec shadi-ollama-1 ollama pull alibayram/medgemma:27b
 docker exec shadi-ollama-1 ollama pull qwen2.5:7b
 docker exec shadi-ollama-1 ollama pull nomic-embed-text
 docker exec shadi-ollama-1 ollama pull phi4:14b

--- a/agents/base.py
+++ b/agents/base.py
@@ -13,7 +13,7 @@ Two inference servers run in parallel (see ADR-002):
   because Ollama does not support LoRA hot-swapping.
 
 - **Ollama** (``OLLAMA_BASE_URL``, default port 11434) — serves all other
-  models: ``medgemma:27b`` (image), ``qwen2.5:7b`` (intake),
+  models: ``alibayram/medgemma:27b`` (image), ``qwen2.5:7b`` (intake),
   ``nomic-embed-text`` (evidence retrieval), ``phi4:14b`` (safety veto),
   ``deepseek-r1:32b`` (orchestrator).
 

--- a/agents/specialists/image_agent.py
+++ b/agents/specialists/image_agent.py
@@ -1,6 +1,6 @@
 """Image analysis agent — radiology / multimodal interpretation.
 
-Model: medgemma:27b via Ollama (see ADR-002)
+Model: alibayram/medgemma:27b via Ollama (see ADR-002)
 Inference server: OLLAMA_BASE_URL
 
 If the case carries no ``imaging_attachments`` the agent returns an empty
@@ -49,7 +49,7 @@ class ImageAnalysisAgent(BaseAgent[SpecialistResult]):
 
     name = "image-analysis"
     domain = "imaging"
-    model = "medgemma:27b"
+    model = "alibayram/medgemma:27b"
     inference_url = settings.OLLAMA_BASE_URL
 
     async def reason(self, case: CaseObject) -> SpecialistResult:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,7 +34,7 @@ services:
       start_period: 120s
 
   # ─── Inference: Ollama (all non-specialist agents) ───────────────────────────
-  # Serves: medgemma:27b (image), qwen2.5:7b (intake), nomic-embed-text
+  # Serves: alibayram/medgemma:27b (image), qwen2.5:7b (intake), nomic-embed-text
   # (evidence retrieval), phi4:14b (safety veto), deepseek-r1:32b (orchestrator).
   # All expose an OpenAI-compatible /v1 endpoint identical to vLLM. See ADR-002.
   ollama:
@@ -94,7 +94,7 @@ services:
       - VLLM_BASE_URL=http://vllm:8080/v1
       - OLLAMA_BASE_URL=http://ollama:11434/v1
       # Model assignments — see ADR-002
-      - IMAGE_MODEL=medgemma:27b
+      - IMAGE_MODEL=alibayram/medgemma:27b
       - INTAKE_MODEL=qwen2.5:7b
       - EVIDENCE_EMBED_MODEL=nomic-embed-text
       - SAFETY_MODEL=phi4:14b

--- a/docs/decisions/adr-002-model-assignments.md
+++ b/docs/decisions/adr-002-model-assignments.md
@@ -15,11 +15,11 @@ A second inference server (Ollama) runs alongside vLLM. Both expose an OpenAI-co
 
 ## Model Assignments
 
-### Image Analysis Agent → `medgemma:27b` (Ollama)
+### Image Analysis Agent → `alibayram/medgemma:27b` (Ollama)
 
-**Rationale:** MedGemma 1.5 is Google's multimodal model purpose-built for medical imaging. It handles radiographs, ECGs, chest X-rays, and CT scout images attached to an encounter before the case reaches the specialist agents. No general-purpose vision model approaches its performance on clinical imaging tasks at this parameter count.
+**Rationale:** MedGemma 1.5 is Google's multimodal model purpose-built for medical imaging. It handles radiographs, ECGs, chest X-rays, and CT scout images attached to an encounter before the case reaches the specialist agents. No general-purpose vision model approaches its performance on clinical imaging tasks at this parameter count. The Ollama registry tag is `alibayram/medgemma:27b` (the bare `medgemma:27b` library tag does not exist in the Ollama registry).
 
-**Approximate VRAM:** ~16 GB (Q4\_K\_M)
+**Approximate VRAM:** ~17 GB (Q4\_K\_M)
 
 ---
 
@@ -70,7 +70,7 @@ A second inference server (Ollama) runs alongside vLLM. Both expose an OpenAI-co
 
 | Agent | Model | Inference server | Approx VRAM |
 |---|---|---|---|
-| Image analysis | `medgemma:27b` | Ollama | ~16 GB |
+| Image analysis | `alibayram/medgemma:27b` | Ollama | ~17 GB |
 | Specialists ×4 (base) | `meditron:70b` FP4 | vLLM | ~38 GB |
 | Specialist LoRA adapters ×4 | — | vLLM | ~8 GB |
 | Intake | `qwen2.5:7b` | Ollama | ~4.5 GB |
@@ -107,5 +107,5 @@ vLLM is kept for Meditron-70B exclusively because Ollama does not support LoRA h
 
 ## Unknowns
 
-- Whether `medgemma:27b` multimodal support is stable in the Ollama runtime at the time of deployment; fallback is direct HuggingFace `transformers` inference.
+- Whether `alibayram/medgemma:27b` multimodal support is stable in the Ollama runtime at the time of deployment; fallback is direct HuggingFace `transformers` inference.
 - Whether `deepseek-r1:32b` produces sufficiently deterministic structured output for the FHIR synthesis step, or whether output parsing guard-rails are needed.

--- a/tests/unit/test_agents.py
+++ b/tests/unit/test_agents.py
@@ -95,7 +95,7 @@ def test_all_agents_have_describe():
 def test_describe_returns_correct_values():
     expected = {
         IntakeAgent: ("intake", "intake", "qwen2.5:7b"),
-        ImageAnalysisAgent: ("image-analysis", "imaging", "medgemma:27b"),
+        ImageAnalysisAgent: ("image-analysis", "imaging", "alibayram/medgemma:27b"),
         CardiologyAgent: ("cardiology", "cardiology", "cardiology"),
         NeurologyAgent: ("neurology", "neurology", "neurology"),
         PulmonologyAgent: ("pulmonology", "pulmonology", "pulmonology"),


### PR DESCRIPTION
The bare medgemma:27b tag does not exist in the Ollama registry. The correct namespaced tag is alibayram/medgemma:27b (~17 GB). Updated all references across agents, config, compose, docs, and tests.

Made-with: Cursor

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated image-analysis model configuration across environment files, Docker setup, and service configuration with a new model identifier.

* **Documentation**
  * Updated all documentation and decision records to reflect the image-analysis model change and increased VRAM requirement (from approximately 16GB to 17GB).

* **Tests**
  * Updated unit tests to validate image analysis agent functionality with the updated model configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->